### PR TITLE
Update to 1.2.0

### DIFF
--- a/_preload.lua
+++ b/_preload.lua
@@ -3,7 +3,7 @@ local api = p.api
 
 p.extensions     = p.extensions or {}
 p.extensions.pkg = {
-	_VERSION     = "1.1.2",
+	_VERSION     = "1.2.0",
 	dir          = common:scriptDir(),
 	reloadRepos  = true,
 	repos        = {

--- a/ext.lua
+++ b/ext.lua
@@ -5,12 +5,12 @@ function pkg:requireExtension(extension)
 	self:updateRepos()
 	
 	local ext, version = self:splitPkgName(extension)
-	local exte, repo   = self:getExtension(ext)
-	if not exte then
+	local exts         = self:getExtensions(ext)
+	if not exts or #exts == 0 then
 		error(string.format("Failed to find extension '%s'", ext))
 	end
-	local range = self:semverRange(version, true)
-	local vers  = self:getPkgVersion(exte, range)
+	local range            = self:semverRange(version, true)
+	local repo, exte, vers = self:getPkgVersion(exts, range)
 	if not vers then
 		error(string.format("Failed to find version '%s' for extension '%s'", version, extension))
 	end

--- a/pkg.lua
+++ b/pkg.lua
@@ -60,7 +60,7 @@ function pkg:requirePackage(pack)
 	end
 	
 	if vers.loaded then
-		self:runDependencyScript(repo, packag, vers)
+		self:runDepScript(repo, packag, vers)
 		return
 	end
 	

--- a/pkg.lua
+++ b/pkg.lua
@@ -49,12 +49,12 @@ function pkg:requirePackage(pack)
 	self:updateRepos()
 	
 	local packa, version = self:splitPkgName(pack)
-	local packag, repo   = self:getPackage(packa)
-	if not packag then
+	local packs          = self:getPackages(packa)
+	if not packs or #packs == 0 then
 		error(string.format("Failed to find package '%s'", packa))
 	end
-	local range = self:semverRange(version, true)
-	local vers  = self:getPkgVersion(packag, range)
+	local range              = self:semverRange(version, true)
+	local repo, packag, vers = self:getPkgVersion(packs, range)
 	if not vers then
 		error(string.format("Failed to find version '%s' for package '%s'", version, packa))
 	end

--- a/pkg.lua
+++ b/pkg.lua
@@ -24,7 +24,7 @@ function pkg:getGenericBuildTool(configs, buildDir)
 		info.configs[config] = {}
 	end
 	info.binDir   = string.format("%s/Bin/", self.currentlyBuildingPackage.version.fullPath)
-	info.buildDir = path.normalize(buildDir)
+	info.buildDir = path.normalize(buildDir) .. "/"
 	function info:mapConfigs(configMap)
 		for config, data in pairs(configMap) do
 			local cfg = self.configs[config]

--- a/pkgbuilders/msbuild.lua
+++ b/pkgbuilders/msbuild.lua
@@ -23,7 +23,7 @@ function pkg:getMSBuild(configs, buildDir)
 	function info:build()
 		for config, data in pairs(self.configs) do
 			for target, dat in pairs(data.data.targets) do
-				dat.fullPath = self.solution .. pkg:formatString(self.pathFmt, { targetname = target, targetpath = dat.path, config = config })
+				dat.fullPath = self.buildDir .. pkg:formatString(self.pathFmt, { targetname = target, targetpath = dat.path, config = config })
 			end
 
 			if not os.executef("call %q -verbosity:minimal -p:Configuration=%s -m %q", self.msbuild, config, self.solution) then

--- a/repo.lua
+++ b/repo.lua
@@ -210,11 +210,11 @@ function pkg:splitPkgName(name)
 end
 
 function pkg:addRepo(repo)
-	table.insert(self.repos, {
+	table.insert(self.repos, 1, {
 		path    = repo,
 		updated = false,
 		cloned  = false
-	}, 1)
+	})
 	self.updateRepos = true
 end
 

--- a/repo.lua
+++ b/repo.lua
@@ -7,13 +7,13 @@ local pkg = p.extensions.pkg
 pkg.supportedRepoVersions = { nil, 0 }
 
 newoption({
-	trigger     = "pkg-prune",
+	trigger     = "pkg-purge",
 	description = "Redownloads used repositories",
 	category    = "pkg"
 })
 
 newoption({
-	trigger     = "pkg-prune-full",
+	trigger     = "pkg-purge-full",
 	description = "Deletes all repositories first",
 	category    = "pkg"
 })

--- a/repo.lua
+++ b/repo.lua
@@ -337,6 +337,7 @@ function pkg:getPkgVersion(pack, version)
 			end
 		end
 	end
+	-- TODO(MarcasRealAccount): If version is not supported, maybe check the next package in the list
 	return newestVersion
 end
 

--- a/repo.lua
+++ b/repo.lua
@@ -262,7 +262,7 @@ function pkg:updateRepos()
 		return
 	end
 	self.reloadRepos = false
-	if _OPTIONS["pkg-prune-full"] then
+	if _OPTIONS["pkg-purge-full"] then
 		common:rmdir(string.format("%s/repos/", self.dir))
 	end
 	for _, repo in ipairs(self.repos) do

--- a/repoapis/github.lua
+++ b/repoapis/github.lua
@@ -7,7 +7,7 @@ local github        = pkg.repoapis.github
 function github:updateRepo(repo, repoPath)
 	repo.dir = pkg.dir .. "/repos/github-" .. repoPath:gsub("/", "-") .. "/"
 	if os.isdir(repo.dir) then
-		if _OPTIONS["pkg-prune"] then
+		if _OPTIONS["pkg-purge"] then
 			common:rmdir(repo.dir)
 		else
 			repo.cloned = true


### PR DESCRIPTION
Rename --pkg-prune to --pkg--purge, this happens early enough that it doesn't even need a deprecation.  
Some double package usage fixes (previously it would fail due to calling an old method that was renamed).  
MSBuild fix.  
Now a package is selected from a list of packages matching the given name, this means it looks for all packages with the given name, then goes through the list of packages and finds the first package with a version in the given range, if the package has no matches it continues to the next one, meaning now two repositories can implement a given package, and if repo a has 1.0.0 and repo b has 2.0.0, then requesting version 1.0.0 will select repo a, with 2.0.0 it will select repo b. (Bad explanation, but it is somewhat difficult to explain properly)